### PR TITLE
fix(263): Apply chartStyle to remaining SVG elements

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -144,7 +144,7 @@ export const convertHTMLToPDF = (
 							cx={attribs.cx}
 							cy={attribs.cy}
 							r={attribs.r}
-							style={getSvgElementStyle(attribs)}
+							style={getSvgElementStyle(attribs, chartStyle)}
 						>
 							{children}
 						</Circle>
@@ -172,13 +172,20 @@ export const convertHTMLToPDF = (
 							cy={attribs.cy}
 							rx={attribs.rx}
 							ry={attribs.ry}
-							style={getSvgElementStyle(attribs)}
+							style={getSvgElementStyle(attribs, chartStyle)}
 						>
 							{children}
 						</Ellipse>
 					);
 				case 'g':
-					return <G {...baseProps}>{children}</G>;
+					return (
+						<G
+							{...baseProps}
+							style={Object.assign({}, ...getElementStyle(attribs, chartStyle))}
+						>
+							{children}
+						</G>
+					);
 				case 'img':
 					return (
 						<Image
@@ -199,7 +206,7 @@ export const convertHTMLToPDF = (
 					return (
 						<Line
 							{...baseProps}
-							style={getSvgElementStyle(attribs)}
+							style={getSvgElementStyle(attribs, chartStyle)}
 							x1={attribs.x1}
 							x2={attribs.x2}
 							y1={attribs.y1}
@@ -230,7 +237,7 @@ export const convertHTMLToPDF = (
 						<Path
 							{...baseProps}
 							d={attribs.d}
-							style={getSvgElementStyle(attribs)}
+							style={getSvgElementStyle(attribs, chartStyle)}
 						>
 							{children}
 						</Path>
@@ -240,7 +247,7 @@ export const convertHTMLToPDF = (
 						<Polygon
 							{...baseProps}
 							points={attribs.points}
-							style={getSvgElementStyle(attribs)}
+							style={getSvgElementStyle(attribs, chartStyle)}
 						>
 							{children}
 						</Polygon>
@@ -250,7 +257,7 @@ export const convertHTMLToPDF = (
 						<Polyline
 							{...baseProps}
 							points={attribs.points}
-							style={getSvgElementStyle(attribs)}
+							style={getSvgElementStyle(attribs, chartStyle)}
 						>
 							{children}
 						</Polyline>
@@ -276,7 +283,7 @@ export const convertHTMLToPDF = (
 							height={attribs.height}
 							rx={attribs.rx}
 							ry={attribs.ry}
-							style={getSvgElementStyle(attribs)}
+							style={getSvgElementStyle(attribs, chartStyle)}
 							width={attribs.width}
 							x={attribs.x}
 							y={attribs.y}

--- a/src/styling.ts
+++ b/src/styling.ts
@@ -83,10 +83,21 @@ export const getElementStyle = (
 	return style;
 };
 
-// For SVG elements this will process inline styles into something react-pdf
-// can understand
-export const getSvgElementStyle = (attribs: TagElementType['attribs']) => {
+// For SVG elements this will process class names and inline styles into
+// something react-pdf can understand
+export const getSvgElementStyle = (
+	attribs: TagElementType['attribs'],
+	chartStyle?: PropsType['chartStyle'],
+) => {
 	const style: SVGPresentationAttributes = {};
+
+	if (attribs.class) {
+		for (const className of attribs.class.split(' ')) {
+			if (chartStyle && className in chartStyle) {
+				Object.assign(style, chartStyle[className]);
+			}
+		}
+	}
 
 	// Apply inline styles that react-pdf supports
 	if (attribs.style) {


### PR DESCRIPTION
## Summary
- `chartStyle` now maps class names on `circle`, `ellipse`, `g`, `line`, `path`, `polygon`, `polyline`, and `rect`, not only `svg`/`text`.
- Completes the follow-up from #263 after the original `svg` fix in v0.2.5.

## Test plan
- [ ] Pass a `chartStyle` entry for a recharts shape class (e.g. `recharts-rectangle` or `recharts-cartesian-grid-horizontal`) and confirm it applies in a PDF.
- [ ] Confirm existing `recharts-text` / `recharts-surface` `chartStyle` mappings still work.
- [ ] `bun run lint`

Closes #263

Made with [Cursor](https://cursor.com)